### PR TITLE
Add a publishing action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Lint
-        run: hatch run lint:fmt
+        uses: Fusion-Power-Plant-Framework/fppf-actions/hatch-lint@main
 
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+
+    environment: release
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup python and Hatch
+        uses: Fusion-Power-Plant-Framework/fppf-actions/setup-hatch@main
+      - name: Build package
+        run: hatch build
+      - name: Run all tests with coverage
+        run: hatch run test:tests-cov
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a publishing action and uses fppf-actions for the linting. The publishing action may fail but thats the easiest way to test, we can do a few dev releases.