### PR TITLE
Be considerate of logging as library code

### DIFF
--- a/csl_reference/__init__.py
+++ b/csl_reference/__init__.py
@@ -3,6 +3,16 @@
 # SPDX-License-Identifier: MIT
 """Package to represent references."""
 
+import logging
+
 from csl_reference._reference import DateVariable, NameVariable, Reference, ReferenceType
 
-__all__ = ["DateVariable", "NameVariable", "Reference", "ReferenceType"]
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+__all__ = [
+    "DateVariable",
+    "NameVariable",
+    "Reference",
+    "ReferenceType",
+]

--- a/csl_reference/_reference.py
+++ b/csl_reference/_reference.py
@@ -21,10 +21,7 @@ from citeproc import (
 from citeproc.source.json import CiteProcJSON
 from pydantic import BaseModel, Field
 
-logging.basicConfig()
-logger = logging.getLogger("reference")
-logger.setLevel(logging.INFO)
-
+logger = logging.getLogger(__name__).parent
 
 __all__ = ["DateVariable", "NameVariable", "Reference", "ReferenceType"]
 


### PR DESCRIPTION
By setting up basicConfig downstream packages get bombarded with logging. This only sets up a stderr handler at WARNING which is the only logging we have currently 